### PR TITLE
Fix to allow JDK 9 builds > 129

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,3 @@ For proper use
 - Add firewall rules to redirect 8080 -> 80 and 8443 -> 443.
 - shell in a box is required for the JEP 286 demo. It's nice to show even if the JEP does not make Java 9.
 - createuser.sh can create users on the shell in a box machine.
-
-Notes
-- It's 'hard coded' that users use Java 9 build 120-129, but update the unit test io.r3k.hackathon.hvcjava9.controllers.SubmitControllerTest if that is not the case.

--- a/src/main/java/io/r3k/hackathon/hvcjava9/controllers/SubmitController.java
+++ b/src/main/java/io/r3k/hackathon/hvcjava9/controllers/SubmitController.java
@@ -44,7 +44,7 @@ public class SubmitController {
     @RequestMapping(method = RequestMethod.POST, value = "go/uploadjavaversion")
     public SubmitResult step1UploadJavaVersion(@RequestParam("source") String input, Principal principal) {
         log.info("step1UploadJavaVersion " + input + " " + principal.getName());
-        if (input.contains("9-ea+12")) {
+        if (input.matches("(?s).*9-ea\\+1[2-9]\\d.*")) {
             getScore(principal.getName()).setStep1(1);
             sendUpdate();
             return new SubmitResult(true, null, "/jshellchallenge.html");

--- a/src/test/java/io/r3k/hackathon/hvcjava9/controllers/SubmitControllerTest.java
+++ b/src/test/java/io/r3k/hackathon/hvcjava9/controllers/SubmitControllerTest.java
@@ -80,6 +80,22 @@ public class SubmitControllerTest {
     }
 
     @Test
+    public void shouldDetectUploadJava9VersionForStep1WithMinimalInputWith13xVersion() {
+        //given
+        String input = "9-ea+131";
+        Principal userPrincipal = mock(Principal.class);
+        String user = UUID.randomUUID().toString();
+        when(userPrincipal.getName()).thenReturn(user);
+        final SubmitController submitController = new SubmitController(mock(SimpMessagingTemplate.class),inMemoryUserDetailsManager);
+        //when
+        SubmitResult result = submitController.step1UploadJavaVersion(input, userPrincipal);
+        //then
+        assertTrue(result.isSuccess());
+        UserScore score = submitController.getScore(user);
+        assertEquals(1, score.getStep1());
+    }
+
+    @Test
     public void shouldNotDetectJava9AsItsJava8() {
         //given
         String input = "java version \"1.8.0_45\"\n"


### PR DESCRIPTION
Update the check use to detect the build number in the Java version so it can handle builds other than 120  - 129
